### PR TITLE
docs: clarify coordinate pair format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Conversor Lat/Lon → ETRS89 / UTM (Streamlit)
 
-App web para convertir coordenadas **geográficas** (latitud/longitud) a coordenadas planas **X,Y en metros** usando **ETRS89 / UTM**.
+App web para convertir coordenadas **geográficas** (latitud/longitud) a coordenadas planas **X, Y en metros** usando **ETRS89 / UTM**.
 Pensada para Lleida y España: por defecto asume **ETRS89 geográficas (EPSG:4258)** y permite salida en **UTM 31N (EPSG:25831)** u otros husos.
 
 ---


### PR DESCRIPTION
## Summary
- clarify coordinate pair format by adding space in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895e25d3c488330b96c66e16d7fa183