### PR TITLE
Remove unused imports from ETRS89 converter app

### DIFF
--- a/etrs89_converter_app.py
+++ b/etrs89_converter_app.py
@@ -1,8 +1,5 @@
 
-import math
-import io
 import pandas as pd
-from pyproj import Transformer
 import streamlit as st
 
 from converter import convert_dataframe


### PR DESCRIPTION
## Summary
- Remove unused `math`, `io`, and `Transformer` imports

## Testing
- `ruff check etrs89_converter_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895e8e1096083309dbe4e3734ce7552