### PR TITLE
Validate column names for dataframe conversion

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -36,10 +36,14 @@ def convert_dataframe(
 
     Returns
     -------
-    Tuple[pd.DataFrame, int, int]
+        Tuple[pd.DataFrame, int, int]
         The converted DataFrame along with the number of valid rows and the
         number of discarded rows.
     """
+    if lat_col not in df.columns:
+        raise ValueError(f"Column '{lat_col}' not found in DataFrame")
+    if lon_col not in df.columns:
+        raise ValueError(f"Column '{lon_col}' not found in DataFrame")
 
     df2 = df.copy()
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -39,6 +39,19 @@ def test_decimal_comma_false_raises():
         convert_dataframe(df, "Lat", "Lon", mode="force_31n")
 
 
+@pytest.mark.parametrize(
+    "cols,missing",
+    [
+        ({"Lat": [41.0]}, "Lon"),
+        ({"Lon": [1.0]}, "Lat"),
+    ],
+)
+def test_missing_columns_raise(cols, missing):
+    df = pd.DataFrame(cols)
+    with pytest.raises(ValueError, match=missing):
+        convert_dataframe(df, "Lat", "Lon", mode="force_31n")
+
+
 def test_auto_multiple_zones():
     df = pd.DataFrame(
         {"Lat": [43.0, 40.0, 41.5], "Lon": [-8.0, -3.0, 1.5]}


### PR DESCRIPTION
## Summary
- ensure `convert_dataframe` checks for missing latitude or longitude columns
- test for `ValueError` when required columns are absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895ebc0b1dc8330b26cb0bf2b89923d