### PR TITLE
Add auto boundary and fixed mode tests

### DIFF
--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -74,3 +74,70 @@ def test_auto_multiple_zones():
         assert out.loc[idx, "X_ETRS89"] == pytest.approx(x, abs=0.001)
         assert out.loc[idx, "Y_ETRS89"] == pytest.approx(y, abs=0.001)
 
+
+def test_auto_zone_boundaries():
+    df = pd.DataFrame({"Lat": [40.0, 40.0, 40.0], "Lon": [-12.0, -6.0, 0.0]})
+    out, n_valid, n_drop = convert_dataframe(df, "Lat", "Lon", mode="auto")
+    assert n_valid == 3
+    assert n_drop == 0
+    assert out["Huso"].tolist() == [29, 30, 31]
+    assert out["EPSG_destino"].tolist() == [
+        "EPSG:25829",
+        "EPSG:25830",
+        "EPSG:25831",
+    ]
+    expected = []
+    for zone, lon, lat in zip([29, 30, 31], df["Lon"], df["Lat"]):
+        transformer = Transformer.from_crs(
+            "EPSG:4258", f"EPSG:258{zone:02d}", always_xy=True
+        )
+        expected.append(transformer.transform(lon, lat))
+    for idx, (x, y) in enumerate(expected):
+        assert out.loc[idx, "X_ETRS89"] == pytest.approx(x, abs=0.001)
+        assert out.loc[idx, "Y_ETRS89"] == pytest.approx(y, abs=0.001)
+
+
+def test_auto_clamps_longitudes():
+    df = pd.DataFrame({"Lat": [40.0, 40.0], "Lon": [-25.0, 9.0]})
+    out, n_valid, n_drop = convert_dataframe(df, "Lat", "Lon", mode="auto")
+    assert n_valid == 2
+    assert n_drop == 0
+    assert out["Huso"].tolist() == [29, 31]
+    assert out["EPSG_destino"].tolist() == [
+        "EPSG:25829",
+        "EPSG:25831",
+    ]
+    expected = []
+    for zone, lon, lat in zip([29, 31], df["Lon"], df["Lat"]):
+        transformer = Transformer.from_crs(
+            "EPSG:4258", f"EPSG:258{zone:02d}", always_xy=True
+        )
+        expected.append(transformer.transform(lon, lat))
+    for idx, (x, y) in enumerate(expected):
+        assert out.loc[idx, "X_ETRS89"] == pytest.approx(x, abs=0.001)
+        assert out.loc[idx, "Y_ETRS89"] == pytest.approx(y, abs=0.001)
+
+
+def test_fixed_mode_coordinates():
+    df = pd.DataFrame({"Lat": [40.0], "Lon": [-3.0]})
+    out, n_valid, n_drop = convert_dataframe(
+        df, "Lat", "Lon", mode="fixed", fixed_zone=30
+    )
+    assert n_valid == 1
+    assert n_drop == 0
+    row = out.loc[0]
+    assert row["Huso"] == 30
+    transformer = Transformer.from_crs(
+        "EPSG:4258", "EPSG:25830", always_xy=True
+    )
+    x, y = transformer.transform(-3.0, 40.0)
+    assert row["X_ETRS89"] == pytest.approx(x, abs=0.001)
+    assert row["Y_ETRS89"] == pytest.approx(y, abs=0.001)
+    assert row["EPSG_destino"] == "EPSG:25830"
+
+
+def test_fixed_mode_requires_zone():
+    df = pd.DataFrame({"Lat": [40.0], "Lon": [-3.0]})
+    with pytest.raises(ValueError):
+        convert_dataframe(df, "Lat", "Lon", mode="fixed")
+


### PR DESCRIPTION
## Summary
- test auto mode at zone boundaries and out-of-range longitudes
- add fixed mode coverage including missing `fixed_zone`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895ed5bd13083309811a13aa8a68b38