### PR TITLE
feat: configurable rounding precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ Se abrirá en `http://localhost:8501`.
 
 ---
 
+## 💻 Uso en Python
+
+```python
+import pandas as pd
+from etrs89_converter.converter import convert_dataframe
+
+df = pd.DataFrame({"Lat": [41.84346], "Lon": [1.03335]})
+out, _, _ = convert_dataframe(df, "Lat", "Lon", mode="force_31n", round_decimals=2)
+```
+
+El parámetro `round_decimals` permite fijar la precisión de salida (por defecto 3 decimales).
+
+---
+
 ## 🛠️ Consejos y resolución de problemas
 - **Resultados inesperados**: Revisa que **no hayas intercambiado lat/lon**, que el **datum** sea correcto y la **coma decimal** esté marcada si aplica.
 - **Coordenadas fuera de España**: El modo *Auto por huso* limita a 29–31N. Para otras zonas, usa *Fijar huso manual*.

--- a/src/etrs89_converter/converter.py
+++ b/src/etrs89_converter/converter.py
@@ -12,6 +12,7 @@ def convert_dataframe(
     fixed_zone: int | None = None,
     use_decimal_comma: bool = False,
     input_epsg: str = "EPSG:4258",
+    round_decimals: int = 3,
 ):
     """Convert a DataFrame of geographic coordinates to ETRS89/UTM.
 
@@ -33,6 +34,8 @@ def convert_dataframe(
         parsing.
     input_epsg:
         EPSG code of the input geographic coordinates.
+    round_decimals:
+        Number of decimal places to round the output coordinates (default 3).
 
     Returns
     -------
@@ -123,8 +126,8 @@ def convert_dataframe(
     else:
         raise ValueError(f"Unknown mode: {mode}")
 
-    results["X_ETRS89"] = results["X_ETRS89"].round(3)
-    results["Y_ETRS89"] = results["Y_ETRS89"].round(3)
+    results["X_ETRS89"] = results["X_ETRS89"].round(round_decimals)
+    results["Y_ETRS89"] = results["Y_ETRS89"].round(round_decimals)
 
     out = pd.concat(
         [df_out.reset_index(drop=True), results.reset_index(drop=True)],

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -35,6 +35,22 @@ def test_decimal_comma_false_raises():
         convert_dataframe(df, "Lat", "Lon", mode="force_31n")
 
 
+def test_round_decimals_changes_precision():
+    df = pd.DataFrame({"Lat": [41.84346], "Lon": [1.03335]})
+    out2, _, _ = convert_dataframe(
+        df, "Lat", "Lon", mode="force_31n", round_decimals=2
+    )
+    out4, _, _ = convert_dataframe(
+        df, "Lat", "Lon", mode="force_31n", round_decimals=4
+    )
+    row2 = out2.loc[0]
+    row4 = out4.loc[0]
+    assert row2["X_ETRS89"] == 336724.56
+    assert row2["Y_ETRS89"] == 4634265.72
+    assert row4["X_ETRS89"] == 336724.5628
+    assert row4["Y_ETRS89"] == 4634265.7204
+
+
 @pytest.mark.parametrize(
     "cols,missing",
     [


### PR DESCRIPTION
## Summary
- allow setting rounding precision with new `round_decimals` parameter in `convert_dataframe`
- document precision parameter and usage in README
- add tests for varying rounding precision

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f16ccadc8330aae975ed19c83fc2