### PR TITLE
Enable automatic CSV delimiter detection

### DIFF
--- a/etrs89_converter_app.py
+++ b/etrs89_converter_app.py
@@ -27,7 +27,12 @@ uploaded = st.file_uploader("Sube un archivo CSV o Excel", type=["csv", "xlsx", 
 
 # Opciones de lectura CSV
 is_csv = False
-sep_map = {"Auto (, por defecto)": None, "Coma (,)": ",", "Punto y coma (;)": ";", "Tabulación (TAB)": "\t"}
+sep_map = {
+    "Auto (detectar automáticamente)": None,
+    "Coma (,)": ",",
+    "Punto y coma (;)": ";",
+    "Tabulación (TAB)": "\t",
+}
 encodings = ["utf-8", "latin-1", "cp1252"]
 
 if uploaded is not None:
@@ -35,14 +40,19 @@ if uploaded is not None:
     if name.endswith(".csv"):
         is_csv = True
         st.markdown("### Opciones de lectura (CSV)")
-        sel_sep = st.selectbox("Separador", options=list(sep_map.keys()), index=0)
+        sel_sep = st.selectbox(
+            "Separador (Auto detecta)", options=list(sep_map.keys()), index=0
+        )
         sep = sep_map[sel_sep]
         enc = st.selectbox("Encoding", options=encodings, index=0)
 
     # Leer archivo
     try:
         if is_csv:
-            df = pd.read_csv(uploaded, sep=sep if sep else ",", encoding=enc)
+            if sep is None:
+                df = pd.read_csv(uploaded, sep=None, engine="python", encoding=enc)
+            else:
+                df = pd.read_csv(uploaded, sep=sep, encoding=enc)
         else:
             df = pd.read_excel(uploaded)  # requiere openpyxl
     except Exception as e:


### PR DESCRIPTION
## Summary
- allow pandas to infer CSV delimiters when "Auto" is selected
- clarify UI text for auto delimiter detection

## Testing
- `pytest -q`
- `python - <<'PY'
import pandas as pd
from io import StringIO
samples = {
    'comma': "a,b\n1,2\n3,4\n",
    'semicolon': "a;b\n1;2\n3;4\n",
    'tab': "a\tb\n1\t2\n3\t4\n",
}
for name, data in samples.items():
    df = pd.read_csv(StringIO(data), sep=None, engine='python')
    print(name, df.to_dict())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6895fe1c87e0833098690e2ba0f44029