### PR TITLE
Validate fixed zone range

### DIFF
--- a/src/etrs89_converter/converter.py
+++ b/src/etrs89_converter/converter.py
@@ -113,6 +113,8 @@ def convert_dataframe(
     elif mode == "fixed":
         if fixed_zone is None:
             raise ValueError("fixed_zone must be provided when mode='fixed'")
+        if fixed_zone not in (29, 30, 31):
+            raise ValueError("fixed_zone must be one of 29, 30, or 31")
         epsg = f"EPSG:258{int(fixed_zone):02d}"
         transformer = Transformer.from_crs(
             input_epsg, epsg, always_xy=True

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -154,3 +154,10 @@ def test_fixed_mode_requires_zone():
         convert_dataframe(df, "Lat", "Lon", mode="fixed")
 
 
+@pytest.mark.parametrize("zone", [28, 32])
+def test_fixed_mode_zone_out_of_range_raises(zone):
+    df = pd.DataFrame({"Lat": [40.0], "Lon": [-3.0]})
+    with pytest.raises(ValueError, match="29, 30, or 31"):
+        convert_dataframe(df, "Lat", "Lon", mode="fixed", fixed_zone=zone)
+
+


### PR DESCRIPTION
## Summary
- Ensure the `fixed` mode validates `fixed_zone` is one of 29, 30, or 31
- Test invalid fixed UTM zones raise a clear `ValueError`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895ff7b9f988330937c81b721a94b43