### PR TITLE
feat: cache pyproj transformers

### DIFF
--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -3,7 +3,12 @@ import pytest
 from pyproj import Transformer
 from pyproj.exceptions import ProjError
 
-from etrs89_converter.converter import convert_dataframe
+from etrs89_converter.converter import _get_transformer, convert_dataframe
+
+
+@pytest.fixture(autouse=True)
+def clear_transformer_cache():
+    _get_transformer.cache_clear()
 
 
 def test_forzar_31n_sample():


### PR DESCRIPTION
## Summary
- cache pyproj Transformer objects keyed by CRS pairs
- reuse cached transformers across all conversion modes
- clear transformer cache automatically for tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896044b496c833092e994dda811d523