### PR TITLE
refactor: add helper for expected coordinates in tests

### DIFF
--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -11,6 +11,16 @@ def clear_transformer_cache():
     _get_transformer.cache_clear()
 
 
+def _expected_coords(zones, lons, lats):
+    coords = []
+    for zone, lon, lat in zip(zones, lons, lats):
+        transformer = Transformer.from_crs(
+            "EPSG:4258", f"EPSG:258{zone:02d}", always_xy=True
+        )
+        coords.append(transformer.transform(lon, lat))
+    return coords
+
+
 def test_forzar_31n_sample():
     df = pd.DataFrame({"Lat": [41.84346], "Lon": [1.03335]})
     out, n_valid, n_drop = convert_dataframe(
@@ -82,12 +92,7 @@ def test_auto_multiple_zones():
         "EPSG:25830",
         "EPSG:25831",
     ]
-    expected = []
-    for zone, lon, lat in zip([29, 30, 31], df["Lon"], df["Lat"]):
-        transformer = Transformer.from_crs(
-            "EPSG:4258", f"EPSG:258{zone:02d}", always_xy=True
-        )
-        expected.append(transformer.transform(lon, lat))
+    expected = _expected_coords([29, 30, 31], df["Lon"], df["Lat"])
     for idx, (x, y) in enumerate(expected):
         assert out.loc[idx, "X_ETRS89"] == pytest.approx(x, abs=0.001)
         assert out.loc[idx, "Y_ETRS89"] == pytest.approx(y, abs=0.001)
@@ -104,12 +109,7 @@ def test_auto_zone_boundaries():
         "EPSG:25830",
         "EPSG:25831",
     ]
-    expected = []
-    for zone, lon, lat in zip([29, 30, 31], df["Lon"], df["Lat"]):
-        transformer = Transformer.from_crs(
-            "EPSG:4258", f"EPSG:258{zone:02d}", always_xy=True
-        )
-        expected.append(transformer.transform(lon, lat))
+    expected = _expected_coords([29, 30, 31], df["Lon"], df["Lat"])
     for idx, (x, y) in enumerate(expected):
         assert out.loc[idx, "X_ETRS89"] == pytest.approx(x, abs=0.001)
         assert out.loc[idx, "Y_ETRS89"] == pytest.approx(y, abs=0.001)
@@ -125,12 +125,7 @@ def test_auto_clamps_longitudes():
         "EPSG:25829",
         "EPSG:25831",
     ]
-    expected = []
-    for zone, lon, lat in zip([29, 31], df["Lon"], df["Lat"]):
-        transformer = Transformer.from_crs(
-            "EPSG:4258", f"EPSG:258{zone:02d}", always_xy=True
-        )
-        expected.append(transformer.transform(lon, lat))
+    expected = _expected_coords([29, 31], df["Lon"], df["Lat"])
     for idx, (x, y) in enumerate(expected):
         assert out.loc[idx, "X_ETRS89"] == pytest.approx(x, abs=0.001)
         assert out.loc[idx, "Y_ETRS89"] == pytest.approx(y, abs=0.001)


### PR DESCRIPTION
## Summary
- add `_expected_coords` helper to compute projected ETRS coordinates
- refactor tests to use helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689605892ba883308bc3e1f1115957bb