### PR TITLE
test: drop invalid coordinate rows

### DIFF
--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -190,3 +190,20 @@ def test_auto_projerror_all_rows_raise():
         )
 
 
+def test_invalid_lat_lon_rows_dropped():
+    df = pd.DataFrame(
+        {
+            "Lat": [41.84346, 100.0, 41.0],
+            "Lon": [1.03335, -3.0, 200.0],
+        }
+    )
+    out, n_valid, n_drop = convert_dataframe(df, "Lat", "Lon", mode="force_31n")
+    assert n_valid == 1
+    assert n_drop == 2
+    assert len(out) == 1
+    row = out.loc[0]
+    assert row["Huso"] == 31
+    assert row["X_ETRS89"] == pytest.approx(336724.563, abs=0.001)
+    assert row["Y_ETRS89"] == pytest.approx(4634265.720, abs=0.001)
+
+


### PR DESCRIPTION
## Summary
- add test ensuring rows with out-of-range latitudes or longitudes are dropped
- verify counters and output for remaining valid row

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896072ab1208330bbf3a8a9ac061c2e